### PR TITLE
Use `framerate` not 8192 as default sampling rate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 PortAudio = "80ea8bcb-4634-5cb3-8ee8-a132660d1d2d"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SignalBase = "00c44e92-20f5-44bc-8f45-a1dcef76ba38"
 
 [compat]
 PortAudio = "1.1"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ using Sound
 S = 8192 # sampling rate in Hz
 x = 0.7*cos.(2pi*(1:S÷2)*440/S)
 y = 0.8*sin.(2pi*(1:S÷2)*660/S)
-sound(x, S) # specify sampling rate
-sound(y) # use default sampling rate of 8192 Hz
-sound([x y]) # stereo
-soundsc([x y], S) # scale to maximum volume
+sound(x, S) # monophonic
+sound([x y], S) # stereo
+soundsc([x y], S) # scale to unit amplitude
 ```
 
 See the
@@ -79,8 +78,14 @@ Tested with Julia ≥ 1.6.
 
 ### Related packages
 
+* https://github.com/haberdashPI/SignalBase.jl
+  supports a `framerate` method that serves as the default sampling rate here.
+* https://github.com/haberdashPI/SignalOperators.jl
+  has useful audio processing operations.
 * https://github.com/dancasimiro/WAV.jl
   has a similar `wavplay` function
+* https://github.com/JuliaAudio
+  has a collection of audio packages.
 * https://github.com/JuliaAudio/PortAudio.jl  
   Currently, the `sound` function here is just a wrapper
   around functions in this package.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ and
 [`soundsc`](https://www.mathworks.com/help/matlab/ref/soundsc.html)
 to facilitate code migration.
 
-
 ## Getting started
 
 ```julia
@@ -45,6 +44,14 @@ soundsc([x y], S) # scale to unit amplitude
 See the
 [documentation](https://jefffessler.github.io/Sound.jl/stable).
 
+
+Matlab's `autoplayer` has the same arguments as `sound`
+so you can type
+`autoplayer = sound`
+and then call
+`autoplayer(x, S)`
+if desired,
+albeit without any of other features of `autoplayer`.
 
 As a nod towards the Julia way of doing things,
 both `sound` and `soundsc`
@@ -74,6 +81,16 @@ soundsc(sb) # scale to maximum volume
 ### Compatibility
 
 Tested with Julia ≥ 1.6.
+
+
+### Caveats
+
+Because Julia code is compiled,
+the first time you call an audio function
+the sound can be jittery.
+Subsequent calls
+(with the same argument types)
+usually work as expected.
 
 
 ### Related packages

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,8 +42,7 @@ using Sound
 S = 8192 # sampling rate in Hz
 x = 0.6 * cos.(2pi*(1:S÷2)*440/S)
 y = 0.7 * sin.(2pi*(1:S÷2)*660/S)
-sound(x, S) # specify sampling rate
-sound(y) # use default sampling rate of 8192 Hz
-sound([x y]) # stereo
+sound(x, S) # monophonic
+sound([x y], S) # stereo
 soundsc([x y], S) # scale to maximum volume
 ```

--- a/src/Sound.jl
+++ b/src/Sound.jl
@@ -1,15 +1,17 @@
 """
     Sound
-Module that exports the `sound` method.
+Module that exports `sound` and `soundsc` methods for audio playback.
 """
 module Sound
 
 using PortAudio: PortAudioStream, write
 using Requires: @require
+import SignalBase: framerate
 
 export sound, soundsc
 
 
+# fallback
 framerate(x::Any) = error("The signal you are trying to play as a sound ",
  "does not have a known sampling rate. ",
  "Consider wrapping in a `SampleBuf` or defining `framerate(x::MyType)`")

--- a/src/Sound.jl
+++ b/src/Sound.jl
@@ -10,22 +10,27 @@ using Requires: @require
 export sound, soundsc
 
 
+framerate(x::Any) = error("The signal you are trying to play as a sound ",
+ "does not have a known sampling rate. ",
+ "Consider wrapping in a `SampleBuf` or defining `framerate(x::MyType)`")
+
+
 """
-    sound(x::AbstractVector, S::Real = 8192)
+    sound(x::AbstractVector, S::Real = framerate(x))
 Play monophonic audio signal `x` at sampling rate `S` samples per second
 through default audio output device using the `PortAudio` package.
-Default sampling rate is `S = 8192` samples per second.
+Caller must specify `S` unless a `framerate` method is defined for `x`.
 """
-sound(x::AbstractVector, S::Real = 8192) = sound(reshape(x, :, 1), S)
+sound(x::AbstractVector, S::Real = framerate(x)) = sound(reshape(x, :, 1), S)
 
 
 """
-    sound(x::AbstractMatrix, S::Real = 8192)
+    sound(x::AbstractMatrix, S::Real = framerate(x))
 Play stereo audio signal `x` at sampling rate `S` samples per second
 through default audio output device using the `PortAudio` package.
-Default sampling rate is `S = 8192` samples per second.
+Caller must specify `S` unless a `framerate` method is defined for `x`.
 """
-function sound(x::AbstractMatrix, S::Real = 8192)
+function sound(x::AbstractMatrix, S::Real = framerate(x))
     if size(x,1) == 1 # row "vector"
         x = vec(x) # convenience
     end
@@ -37,14 +42,10 @@ end
 
 
 """
-    soundsc(x, S::Real = 8192)
-Play mono or stereo audio signal `x`
-at sampling rate `S` samples per second
-through default audio output device using the `PortAudio` package,
-after scaling `x` to have values in `(-1,1)`.
-Default sampling rate is `S = 8192` samples per second.
+    soundsc(x, S::Real = framerate(x))
+Call `sound` after scaling `x` to have values in `(-1,1)`.
 """
-soundsc(x::AbstractArray, S::Real = 8192) =
+soundsc(x::AbstractArray, S::Real = framerate(x)) =
     sound(x * prevfloat(1.0) / maximum(abs, x), S)
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,15 +10,15 @@ using SampledSignals: SampleBuf
     x = 0.8 * cos.(2pi*(1:800)*440/S)
     y = 0.7 * sin.(2pi*(1:800)*660/S)
     sound(x, S) # specify sampling rate
-    sound(y) # use default sampling rate of 8192 Hz
-    sound([x y]) # stereo
+    @test_throws ErrorException sound(y) # unknown sampling rate
+    sound([x y], S) # stereo
     soundsc(0.1 * reshape(x,1,:), S) # scale and row vector
 
     sb = SampleBuf(x, S)
     sound(sb)
     soundsc(sb)
 
-    @test_throws String sound(ones(5,3))
+    @test_throws String sound(ones(5,3), S) # array size
 
     @test isempty(detect_ambiguities(Sound))
 end


### PR DESCRIPTION
Addresses #5 and jettisons the very historical default rate of 8192 Hz.
This will force the caller to specify the sampling rate for signal types (like Vectors) that do not have an associated type.