### PR TITLE
Add elementary `record` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,25 @@ sound(sb)
 soundsc(sb) # scale to maximum volume
 ```
 
+## Audio recording
 
-### Compatibility
+There is also a simple `record` method here
+for recording from the default microphone.
+It returns a Vector of the sample data
+and the audio system default sampling rate.
+
+```julia
+using Sound: record
+data, S = record(4) # record 4 seconds of audio data
+```
+
+
+## Compatibility
 
 Tested with Julia ≥ 1.6.
 
 
-### Caveats
+## Caveats
 
 Because Julia code is compiled,
 the first time you call an audio function
@@ -92,8 +104,16 @@ Subsequent calls
 (with the same argument types)
 usually work as expected.
 
+On MacOS, if you run Julia from an xterm in XQuartz,
+then (at least as of XQuartz v2.8.1)
+no audio will be recorded
+because XQuartz does not ask for permission
+to access the microphone.
+Running Julia within the Terminal app is required
+because Terminal will properly request microphone permissions.
 
-### Related packages
+
+## Related packages
 
 * https://github.com/haberdashPI/SignalBase.jl
   supports a `framerate` method that serves as the default sampling rate here.

--- a/src/Sound.jl
+++ b/src/Sound.jl
@@ -1,55 +1,14 @@
 """
     Sound
-Module that exports `sound` and `soundsc` methods for audio playback.
+
+Module that exports wrappers around audio methods in `PortAudio`.
+* `sound` and `soundsc` : methods for audio playback.
+* `record` : method for audio recording.
 """
 module Sound
 
-using PortAudio: PortAudioStream, write
-using Requires: @require
-import SignalBase: framerate
-
-export sound, soundsc
-
-
-# fallback
-framerate(x::Any) = error("The signal you are trying to play as a sound ",
- "does not have a known sampling rate. ",
- "Consider wrapping in a `SampleBuf` or defining `framerate(x::MyType)`")
-
-
-"""
-    sound(x::AbstractVector, S::Real = framerate(x))
-Play monophonic audio signal `x` at sampling rate `S` samples per second
-through default audio output device using the `PortAudio` package.
-Caller must specify `S` unless a `framerate` method is defined for `x`.
-"""
-sound(x::AbstractVector, S::Real = framerate(x)) = sound(reshape(x, :, 1), S)
-
-
-"""
-    sound(x::AbstractMatrix, S::Real = framerate(x))
-Play stereo audio signal `x` at sampling rate `S` samples per second
-through default audio output device using the `PortAudio` package.
-Caller must specify `S` unless a `framerate` method is defined for `x`.
-"""
-function sound(x::AbstractMatrix, S::Real = framerate(x))
-    if size(x,1) == 1 # row "vector"
-        x = vec(x) # convenience
-    end
-    size(x,2) ≤ 2 || throw("size(x,2) = $(size(x,2)) is too many channels")
-    PortAudioStream(0, 2; samplerate=Float64(S)) do stream
-        write(stream, x)
-    end
-end
-
-
-"""
-    soundsc(x, S::Real = framerate(x))
-Call `sound` after scaling `x` to have values in `(-1,1)`.
-"""
-soundsc(x::AbstractArray, S::Real = framerate(x)) =
-    sound(x * prevfloat(1.0) / maximum(abs, x), S)
-
+include("soundsc.jl")
+include("record.jl")
 
 # support SampledSignals iff user has loaded that package
 function __init__()

--- a/src/record.jl
+++ b/src/record.jl
@@ -1,0 +1,51 @@
+# record.jl
+# elementary audio recording utility function
+
+using PortAudio: PortAudioStream, read
+
+export record
+
+
+"""
+    data, S = record(time::Real = 5; args=(1,0), chat::Bool=true)
+
+Record `time` seconds of audio data using the built-in microphone.
+
+# Input
+* `time` : duration; 5 seconds by default
+
+# Option
+* `args` : arguments to PortAudioStream;
+  `(1,0)` for single-channel input by default
+* `chat` : show begin/end message? `true` by default
+
+# Output
+* `data` : Vector of length `time * S`
+* `S` : `sample_rate` of stream 
+"""
+function record(
+    time::Real = 5 ;
+    args = (1,0),
+    chat::Bool=true,
+    print::Function = (x) -> printstyled(x * "\n"; color=:blue),
+)
+
+    PortAudioStream(args...) do stream
+        S = stream.sample_rate
+        N = round(Int, time * S)
+        if chat
+             print("Begin $time sec recording at rate $S for $N samples.")
+        end
+        buf = read(stream, N)
+        data = buf.data
+        if size(data) == (size(data,1), 1) # N × 1
+            data = vec(data)
+        end
+        @assert buf.samplerate == S
+        if chat
+            ext = round.(extrema(data), digits=2)
+            print("Recording finished; extrema: $ext.")
+        end
+        return data, S
+    end
+end

--- a/src/soundsc.jl
+++ b/src/soundsc.jl
@@ -1,0 +1,47 @@
+# soundsc.jl
+
+using PortAudio: PortAudioStream, write
+using Requires: @require
+import SignalBase: framerate
+
+export sound, soundsc
+
+
+# fallback
+framerate(x::Any) = error("The signal you are trying to play as a sound ",
+ "does not have a known sampling rate. ",
+ "Consider wrapping in a `SampleBuf` or defining `framerate(x::MyType)`")
+
+
+"""
+    sound(x::AbstractVector, S::Real = framerate(x))
+Play monophonic audio signal `x` at sampling rate `S` samples per second
+through default audio output device using the `PortAudio` package.
+Caller must specify `S` unless a `framerate` method is defined for `x`.
+"""
+sound(x::AbstractVector, S::Real = framerate(x)) = sound(reshape(x, :, 1), S)
+
+
+"""
+    sound(x::AbstractMatrix, S::Real = framerate(x))
+Play stereo audio signal `x` at sampling rate `S` samples per second
+through default audio output device using the `PortAudio` package.
+Caller must specify `S` unless a `framerate` method is defined for `x`.
+"""
+function sound(x::AbstractMatrix, S::Real = framerate(x))
+    if size(x,1) == 1 # row "vector"
+        x = vec(x) # convenience
+    end
+    size(x,2) ≤ 2 || throw("size(x,2) = $(size(x,2)) is too many channels")
+    PortAudioStream(0, 2; samplerate=Float64(S)) do stream
+        write(stream, x)
+    end
+end
+
+
+"""
+    soundsc(x, S::Real = framerate(x))
+Call `sound` after scaling `x` to have values in `(-1,1)`.
+"""
+soundsc(x::AbstractArray, S::Real = framerate(x)) =
+    sound(x * prevfloat(1.0) / maximum(abs, x), S)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 # runtests.jl
 
 using Test: @test, @testset, @test_throws, detect_ambiguities
-using Sound # sound, soundsc
+using Sound # sound, soundsc, record
 using SampledSignals: SampleBuf
 
 @testset "Sound" begin
@@ -21,4 +21,11 @@ using SampledSignals: SampleBuf
     @test_throws String sound(ones(5,3), S) # array size
 
     @test isempty(detect_ambiguities(Sound))
+end
+
+
+@testset "record" begin
+	tmp, S = record(0.001)
+	@test S isa Real
+	@test tmp isa Vector
 end


### PR DESCRIPTION
Seems like a package with the broad name `Sound` should have at least one sound input method...